### PR TITLE
lanczos instead of tuned ewa_lanczos

### DIFF
--- a/mpv_linux.conf
+++ b/mpv_linux.conf
@@ -87,8 +87,7 @@ deband-grain=4
 # glsl-shader="~~/shaders/TsubaUP.glsl"				# high
 # glsl-shader="~~/shaders/SSimSuperRes.glsl"			# high
 glsl-shader="~~/shaders/ravu-zoom-r3-rgb.hook"			# medium
-scale=ewa_lanczos
-scale-blur=0.981251
+scale=lanczos
 
 ###### Luma down (optional, uncomment shader line if your hardware can support it)
 # glsl-shader="~~/shaders/SSimDownscaler.glsl"

--- a/mpv_osx.conf
+++ b/mpv_osx.conf
@@ -85,12 +85,12 @@ dither-depth=auto
 # fbo-format is not not supported in gpu-next profile
 glsl-shaders-clr
 # luma upscaling
-scale=ewa_lanczos
+scale=lanczos
 # luma downscaling
 dscale=mitchell
 linear-downscaling=no
 # chroma upscaling and downscaling
-cscale=mitchell
+cscale=lanczos
 sigmoid-upscaling=yes
 
 ###### Debanding 

--- a/mpv_windows.conf
+++ b/mpv_windows.conf
@@ -87,8 +87,7 @@ deband-grain=4
 # glsl-shader="~~/shaders/TsubaUP.glsl"				# high
 # glsl-shader="~~/shaders/SSimSuperRes.glsl"			# high
 glsl-shader="~~/shaders/ravu-zoom-r3-rgb.hook"			# medium
-scale=ewa_lanczos
-scale-blur=0.981251
+scale=lanczos
 
 ###### Luma down (optional, uncomment shader line if your hardware can support it)
 # glsl-shader="~~/shaders/SSimDownscaler.glsl"


### PR DESCRIPTION
lanczos seems to have higher scores in every upscale tests ->  https://artoriuz.github.io/blog/mpv_upscaling.html while it needs ~35% less performance than the previous setting (tuned ewa_lanczos for gpu-next == previously ewa_lanczossharp)
https://artoriuz.github.io/blog/images/mpv_upscaling/tables/fps.png

This is mostly relevant when one doesn't use any shaders, or when used together with those that supplement it (like SSim)

Updated chroma for osx as well. (missed that one before)